### PR TITLE
disable keeping track of lastreviewrecord multihash

### DIFF
--- a/src/modules/reviewrecords.js
+++ b/src/modules/reviewrecords.js
@@ -318,7 +318,10 @@ class ReviewRecords {
     }
 
     setPointerToLastReviewRecord(reviewRecord) {
-        reviewRecord.last_reviewrecord_multihash = this.chluIpfs.lastReviewRecordMultihash || '';
+        // reviewRecord.last_reviewrecord_multihash = this.chluIpfs.lastReviewRecordMultihash || '';
+        // Disable this due to issues with the Publisher API Server.
+        // This will be reenabled when we actually start to use it
+        reviewRecord.last_reviewrecord_multihash = '';
         return reviewRecord;
     }
 

--- a/tests/ReviewRecordsReading.test.js
+++ b/tests/ReviewRecordsReading.test.js
@@ -95,24 +95,6 @@ describe('ReviewRecord reading and other functions', () => {
         expect(isValidMultihash('blah')).to.be.false;
         expect(isValidMultihash({ notEvenA: 'multihash'})).to.be.false;
     });
-
-    it('sets the last review record multihash into new reviews and updates it after storing the review', async () => {
-        const fakeReviewRecord = await getFakeReviewRecord();
-        const lastReviewRecordMultihash = 'QmQ6vGTgqjec2thBj5skqfPUZcsSuPAbPS7XvkqaYNQVPZ';
-        chluIpfs.lastReviewRecordMultihash = lastReviewRecordMultihash.slice(0); // make a copy
-        const fakeStore = {};
-        chluIpfs.ipfsUtils = ipfsUtilsStub(fakeStore);
-        chluIpfs.orbitDb.putReviewRecordAndWaitForReplication = sinon.stub().resolves();
-        chluIpfs.reviewRecords.waitForRemotePin = sinon.stub().resolves();
-        chluIpfs.crypto.generateKeyPair();
-        const multihash = await chluIpfs.storeReviewRecord(fakeReviewRecord, {
-            validate: false,
-            bitcoinTransactionHash: 'fake'
-        });
-        const reviewRecord = chluIpfs.protobuf.ReviewRecord.decode(chluIpfs.ipfsUtils.storeDAGNode.args[0][0].data);
-        expect(reviewRecord.last_reviewrecord_multihash).to.deep.equal(lastReviewRecordMultihash);
-        expect(chluIpfs.lastReviewRecordMultihash).to.deep.equal(multihash);
-    });
     
     it('computes the ReviewRecord hash', async () => {
         const reviewRecord = await getFakeReviewRecord();

--- a/tests/ReviewRecordsStoring.test.js
+++ b/tests/ReviewRecordsStoring.test.js
@@ -223,4 +223,23 @@ describe('ReviewRecord storing and publishing', () => {
         expect(chluIpfs.room.broadcastUntil.args[1][0].bitcoinNetwork).to.be.null
     });
 
+    // Skipping this due to functionality being disabled
+    it.skip('sets the last review record multihash into new reviews and updates it after storing the review', async () => {
+        const fakeReviewRecord = await getFakeReviewRecord();
+        const lastReviewRecordMultihash = 'QmQ6vGTgqjec2thBj5skqfPUZcsSuPAbPS7XvkqaYNQVPZ';
+        chluIpfs.lastReviewRecordMultihash = lastReviewRecordMultihash.slice(0); // make a copy
+        const fakeStore = {};
+        chluIpfs.ipfsUtils = ipfsUtilsStub(fakeStore);
+        chluIpfs.orbitDb.putReviewRecordAndWaitForReplication = sinon.stub().resolves();
+        chluIpfs.reviewRecords.waitForRemotePin = sinon.stub().resolves();
+        chluIpfs.crypto.generateKeyPair();
+        const multihash = await chluIpfs.storeReviewRecord(fakeReviewRecord, {
+            validate: false,
+            bitcoinTransactionHash: 'fake'
+        });
+        const reviewRecord = chluIpfs.protobuf.ReviewRecord.decode(chluIpfs.ipfsUtils.storeDAGNode.args[0][0].data);
+        expect(reviewRecord.last_reviewrecord_multihash).to.deep.equal(lastReviewRecordMultihash);
+        expect(chluIpfs.lastReviewRecordMultihash).to.deep.equal(multihash);
+    });
+
 });


### PR DESCRIPTION
This feature was not used anywhere.

The problem is that it breaks the delegation of publishing reviews to a server, so I disabled this feature for the moment to keep the option of publishing through servers open.

We can reintroduce this later when it actually serves a purpose

@kulpreet what do you think?