### PR TITLE
[WIP] Use SQL Index to compute reputation score

### DIFF
--- a/src/modules/orbitdb/indexes/abstract.js
+++ b/src/modules/orbitdb/indexes/abstract.js
@@ -164,12 +164,20 @@ class ChluAbstractIndex {
         return await this._getReviewsWrittenByDID(didId)
     }
 
+    async getReputationScore(didId) {
+        return await this._getReputationScore(didId)
+    }
+
     async _getReviewsAboutDID() {
         notImplemented();
     }
 
     async _getReviewsWrittenByDID() {
         notImplemented();
+    }
+
+    async _getReputationScore() {
+        notImplemented()
     }
 
 }

--- a/src/modules/orbitdb/indexes/inmemory.js
+++ b/src/modules/orbitdb/indexes/inmemory.js
@@ -133,6 +133,11 @@ class ChluInMemoryIndex extends ChluAbstractIndex {
             .map(multihash => ({ multihash }))
     }
 
+    _getReputationScore() {
+        // The InMemory Index cannot do this.
+        return null
+    }
+
 }
 
 function slice(array, offset, limit) {

--- a/src/modules/orbitdb/indexes/sql.js
+++ b/src/modules/orbitdb/indexes/sql.js
@@ -289,6 +289,35 @@ class ChluSQLIndex extends ChluAbstractIndex {
         return formatReviewRecords(list)
     }
 
+    async _getReputationScore(didId) {
+        const result = await this.ReviewRecord.findAll({
+            attributes: [
+                [this.sequelize.fn('AVERAGE', this.sequelize.col('data.rating_details.value')), 'rating_average'],
+                [this.sequelize.fn('COUNT'), 'rating_count'],
+            ],
+            where: {
+                // Only take out reviews about the didId
+                [Sequelize.Op.or]: [
+                    { 'data.popr.vendor_did': didId },
+                    { 'data.subject.did': didId },
+                ],
+                // that also have a rating between 1 and 5 included
+                'data.rating_details.min': 1,
+                'data.rating_details.max': 5,
+                'data.rating_details.value': {
+                    [Sequelize.Op.gte]: 1,
+                    [Sequelize.Op.lte]: 5
+                },
+                // don't consider records not about the latest version of a review
+                'latestVersionData': null
+            }
+        })
+        return {
+            rating_average: get(result[0], 'rating_average', null),
+            rating_count: get(result[0], 'rating_count', 0),
+        }
+    }
+
 }
 
 function formatReviewRecords(list) {


### PR DESCRIPTION
This is broken at the moment because sequelize says `data.review_details.rating` is not a column in the aggregation function.

Worst case we'll write a plain SQL query, I opened this PR to track current work on this.